### PR TITLE
fix team teleport event missing static getHandlerList()

### DIFF
--- a/src/main/java/dev/xf3d3/ultimateteams/api/events/TeamTeleportEvent.java
+++ b/src/main/java/dev/xf3d3/ultimateteams/api/events/TeamTeleportEvent.java
@@ -33,6 +33,9 @@ public class TeamTeleportEvent extends Event implements Cancellable {
         return HANDLERS;
     }
 
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
 
     @Override
     public boolean isCancelled() {


### PR DESCRIPTION
The team teleport event was missing the static getHandlerList() method. This caused it to be unusable by plugins trying to hook into the API, giving 'org.bukkit.plugin.IllegalPluginAccessException: Unable to find handler list for event dev.xf3d3.ultimateteams.api.events.TeamTeleportEvent. Static getHandlerList method required!'

This fixes it.