### PR TITLE
Update team creation command to use main command

### DIFF
--- a/src/main/java/dev/xf3d3/ultimateteams/gui/NotInTeamManager.java
+++ b/src/main/java/dev/xf3d3/ultimateteams/gui/NotInTeamManager.java
@@ -52,7 +52,7 @@ public class NotInTeamManager {
                     if (click.getType().isLeftClick()) {
 
                         click.getGui().close();
-                        player.performCommand("team create");
+                        player.performCommand(plugin.getSettings().getMainCommand() + " create");
                     }
 
                     return true;


### PR DESCRIPTION
When you changed the main command from the settings, when creating a clan from the GUI, it threw an error.

```
[19:41:54 ERROR]: [UltimateTeams] Exception while trying to run action for click on StaticGuiElement in slot 12 of Menú de Clan GUI!
org.bukkit.command.CommandException: Unhandled exception executing 'team create' in org.bukkit.craftbukkit.command.VanillaCommandWrapper(team)
        at org.bukkit.craftbukkit.CraftServer.dispatchCommand(CraftServer.java:964) ~[purpur-26.1.2.jar:26.1.2-2592-405ad83]
        at org.bukkit.craftbukkit.entity.CraftPlayer.performCommand(CraftPlayer.java:770) ~[purpur-26.1.2.jar:26.1.2-2592-405ad83]
        at UltimateTeams-5.0.4.jar//dev.xf3d3.ultimateteams.gui.NotInTeamManager.lambda$open$1(NotInTeamManager.java:55) ~[?:?]
        at UltimateTeams-5.0.4.jar//dev.xf3d3.ultimateteams.libraries.inventorygui.inventorygui.InventoryGui.handleInteract(InventoryGui.java:1216) ~[?:?]
        at UltimateTeams-5.0.4.jar//dev.xf3d3.ultimateteams.libraries.inventorygui.inventorygui.InventoryGui.access$500(InventoryGui.java:83) ~[?:?]
        at UltimateTeams-5.0.4.jar//dev.xf3d3.ultimateteams.libraries.inventorygui.inventorygui.InventoryGui$GuiListener.onInventoryClick(InventoryGui.java:1326) ~[?:?]
        at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:80) ~[purpur-api-26.1.2.build.2592-stable.jar:?]
        at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:71) ~[purpur-api-26.1.2.build.2592-stable.jar:?]
        at io.papermc.paper.plugin.manager.PaperEventManager.callEvent(PaperEventManager.java:54) ~[purpur-26.1.2.jar:26.1.2-2592-405ad83]
        at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.callEvent(PaperPluginManagerImpl.java:131) ~[purpur-26.1.2.jar:26.1.2-2592-405ad83]
        at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:628) ~[purpur-api-26.1.2.build.2592-stable.jar:?]
        at net.minecraft.server.network.ServerGamePacketListenerImpl.handleContainerClick(ServerGamePacketListenerImpl.java:3444) ~[purpur-26.1.2.jar:26.1.2-2592-405ad83]
        at net.minecraft.network.protocol.game.ServerboundContainerClickPacket.handle(ServerboundContainerClickPacket.java:56) ~[purpur-26.1.2.jar:26.1.2-2592-405ad83]
        at net.minecraft.network.protocol.game.ServerboundContainerClickPacket.handle(ServerboundContainerClickPacket.java:14) ~[purpur-26.1.2.jar:26.1.2-2592-405ad83]
        at net.minecraft.network.PacketProcessor$ListenerAndPacket.handle(PacketProcessor.java:97) ~[purpur-26.1.2.jar:26.1.2-2592-405ad83]
        at net.minecraft.network.PacketProcessor.executeSinglePacket(PacketProcessor.java:33) ~[purpur-26.1.2.jar:26.1.2-2592-405ad83]
        at net.minecraft.server.MinecraftServer.pollTask(MinecraftServer.java:1569) ~[purpur-26.1.2.jar:26.1.2-2592-405ad83]
        at net.minecraft.server.MinecraftServer.recordTaskExecutionTimeWhileWaiting(MinecraftServer.java:1278) ~[purpur-26.1.2.jar:26.1.2-2592-405ad83]
        at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1415) ~[purpur-26.1.2.jar:26.1.2-2592-405ad83]
        at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:304) ~[purpur-26.1.2.jar:26.1.2-2592-405ad83]
        at java.base/java.lang.Thread.run(Thread.java:1474) ~[?:?]
Caused by: com.mojang.brigadier.exceptions.CommandSyntaxException: Incorrect argument for command at position 5: team <--[HERE]
```